### PR TITLE
ADBLOCK & MISSING UI ELEMENTS WORKAROUND & uYou link updated (allowing for 3.0.4)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ before-all::
 	fi
 before-all::
 	@if [[ ! -f $(UYOU_DEB) ]]; then \
- 		curl -s -L "https://www.dropbox.com/scl/fi/01vvu5lm8nkkicrznku9v/com.miro.uyou_$(UYOU_VERSION)_iphoneos-arm.deb?rlkey=efgz7po8kqqvha8doplk1s3ky&dl=1" -o $(UYOU_DEB); \
+ 		curl -s https://repo.miro92.com/debs/com.miro.uyou_$(UYOU_VERSION)_iphoneos-arm.deb -o $(UYOU_DEB); \
  	fi; \
 	if [[ ! -f $(UYOU_DYLIB) || ! -d $(UYOU_BUNDLE) ]]; then \
 		tar -xf Tweaks/uYou/com.miro.uyou_$(UYOU_VERSION)_iphoneos-arm.deb -C Tweaks/uYou; tar -xf Tweaks/uYou/data.tar* -C Tweaks/uYou; \

--- a/Sources/uYouPlusPatches.xm
+++ b/Sources/uYouPlusPatches.xm
@@ -2,62 +2,6 @@
 
 # pragma mark - YouTube patches
 
-/*
-// Fix Google Sign in by @PoomSmart and @level3tjg (qnblackcat/uYouPlus#684)
-%hook NSBundle
-- (NSDictionary *)infoDictionary {
-    NSMutableDictionary *info = %orig.mutableCopy;
-    if ([self isEqual:NSBundle.mainBundle])
-        info[@"CFBundleIdentifier"] = @"com.google.ios.youtube";
-    return info;
-}
-%end
-*/
-
-// Workaround for MiRO92/uYou-for-YouTube#12, qnblackcat/uYouPlus#263
-%hook YTDataUtils
-+ (NSMutableDictionary *)spamSignalsDictionary {
-    return nil;
-}
-+ (NSMutableDictionary *)spamSignalsDictionaryWithoutIDFA {
-    return nil;
-}
-%end
-
-%hook YTHotConfig
-- (BOOL)disableAfmaIdfaCollection { return NO; }
-%end
-
-// Reposition "Create" Tab to the Center in the Pivot Bar - qnblackcat/uYouPlus#107
-/*
-static void repositionCreateTab(YTIGuideResponse *response) {
-    NSMutableArray<YTIGuideResponseSupportedRenderers *> *renderers = [response itemsArray];
-    for (YTIGuideResponseSupportedRenderers *guideRenderers in renderers) {
-        YTIPivotBarRenderer *pivotBarRenderer = [guideRenderers pivotBarRenderer];
-        NSMutableArray<YTIPivotBarSupportedRenderers *> *items = [pivotBarRenderer itemsArray];
-        NSUInteger createIndex = [items indexOfObjectPassingTest:^BOOL(YTIPivotBarSupportedRenderers *renderers, NSUInteger idx, BOOL *stop) {
-            return [[[renderers pivotBarItemRenderer] pivotIdentifier] isEqualToString:@"FEuploads"];
-        }];
-        if (createIndex != NSNotFound) {
-            YTIPivotBarSupportedRenderers *createTab = [items objectAtIndex:createIndex];
-            [items removeObjectAtIndex:createIndex];
-            NSUInteger centerIndex = items.count / 2;
-            [items insertObject:createTab atIndex:centerIndex]; // Reposition the "Create" tab at the center
-        }
-    }
-}
-%hook YTGuideServiceCoordinator
-- (void)handleResponse:(YTIGuideResponse *)response withCompletion:(id)completion {
-    repositionCreateTab(response);
-    %orig(response, completion);
-}
-- (void)handleResponse:(YTIGuideResponse *)response error:(id)error completion:(id)completion {
-    repositionCreateTab(response);
-    %orig(response, error, completion);
-}
-%end
-*/
-
 // https://github.com/PoomSmart/YouTube-X/blob/1e62b68e9027fcb849a75f54a402a530385f2a51/Tweak.x#L27
 // %hook YTAdsInnerTubeContextDecorator
 // - (void)decorateContext:(id)context {}
@@ -92,110 +36,6 @@ static void repositionCreateTab(YTIGuideResponse *response) {
     else { return %orig; }
 }
 %end
-
-// YouTube Native Share - https://github.com/jkhsjdhjs/youtube-native-share - @jkhsjdhjs
-typedef NS_ENUM(NSInteger, ShareEntityType) {
-    ShareEntityFieldVideo = 1,
-    ShareEntityFieldPlaylist = 2,
-    ShareEntityFieldChannel = 3,
-    ShareEntityFieldClip = 8
-};
-
-static inline NSString* extractIdWithFormat(GPBUnknownFieldSet *fields, NSInteger fieldNumber, NSString *format) {
-    if (![fields hasField:fieldNumber])
-        return nil;
-    GPBUnknownField *idField = [fields getField:fieldNumber];
-    if ([idField.lengthDelimitedList count] != 1)
-        return nil;
-    NSString *id = [[NSString alloc] initWithData:[idField.lengthDelimitedList firstObject] encoding:NSUTF8StringEncoding];
-    return [NSString stringWithFormat:format, id];
-}
-static BOOL showNativeShareSheet(NSString *serializedShareEntity) {
-    GPBMessage *shareEntity = [%c(GPBMessage) deserializeFromString:serializedShareEntity];
-    GPBUnknownFieldSet *fields = shareEntity.unknownFields;
-    NSString *shareUrl;
-
-    if ([fields hasField:ShareEntityFieldClip]) {
-        GPBUnknownField *shareEntityClip = [fields getField:ShareEntityFieldClip];
-        if ([shareEntityClip.lengthDelimitedList count] != 1)
-            return NO;
-        GPBMessage *clipMessage = [%c(GPBMessage) parseFromData:[shareEntityClip.lengthDelimitedList firstObject] error:nil];
-        shareUrl = extractIdWithFormat(clipMessage.unknownFields, 1, @"https://youtube.com/clip/%@");
-    }
-
-    if (!shareUrl)
-        shareUrl = extractIdWithFormat(fields, ShareEntityFieldChannel, @"https://youtube.com/channel/%@");
-
-    if (!shareUrl) {
-        shareUrl = extractIdWithFormat(fields, ShareEntityFieldPlaylist, @"%@");
-        if (shareUrl) {
-            if (![shareUrl hasPrefix:@"PL"] && ![shareUrl hasPrefix:@"FL"])
-                shareUrl = [shareUrl stringByAppendingString:@"&playnext=1"];
-            shareUrl = [@"https://youtube.com/playlist?list=" stringByAppendingString:shareUrl];
-        }
-    }
-
-    if (!shareUrl)
-        shareUrl = extractIdWithFormat(fields, ShareEntityFieldVideo, @"https://youtube.com/watch?v=%@");
-
-    if (!shareUrl)
-        return NO;
-
-    UIActivityViewController *activityViewController = [[UIActivityViewController alloc] initWithActivityItems:@[shareUrl] applicationActivities:nil];
-    activityViewController.excludedActivityTypes = @[UIActivityTypeAssignToContact, UIActivityTypePrint];
-
-    UIViewController *topViewController = [%c(YTUIUtils) topViewControllerForPresenting];
-
-    if (activityViewController.popoverPresentationController) {
-        activityViewController.popoverPresentationController.sourceView = topViewController.view;
-
-        CGFloat screenWidth = [UIScreen mainScreen].bounds.size.width;
-        CGFloat screenHeight = [UIScreen mainScreen].bounds.size.height;
-
-        activityViewController.popoverPresentationController.sourceRect = CGRectMake(screenWidth / 2.0, screenHeight, 0, 0);
-        activityViewController.popoverPresentationController.permittedArrowDirections = UIPopoverArrowDirectionAny;
-    }
-    [topViewController presentViewController:activityViewController animated:YES completion:nil];
-    return YES;
-}
-
-/* -------------------- iPad Layout -------------------- */
-
-%hook YTAccountScopedCommandResponderEvent
-- (void)send {
-    GPBExtensionDescriptor *shareEntityEndpointDescriptor = [%c(YTIShareEntityEndpoint) shareEntityEndpoint];
-    if (![self.command hasExtension:shareEntityEndpointDescriptor])
-        return %orig;
-    YTIShareEntityEndpoint *shareEntityEndpoint = [self.command getExtension:shareEntityEndpointDescriptor];
-    if (!shareEntityEndpoint.hasSerializedShareEntity)
-        return %orig;
-    if (!showNativeShareSheet(shareEntityEndpoint.serializedShareEntity))
-        return %orig;
-}
-%end
-
-/* ------------------- iPhone Layout ------------------- */
-
-%hook ELMPBShowActionSheetCommand
-- (void)executeWithCommandContext:(id)_context handler:(id)_handler {
-    if (!self.hasOnAppear)
-        return %orig;
-    GPBExtensionDescriptor *innertubeCommandDescriptor = [%c(YTIInnertubeCommandExtensionRoot) innertubeCommand];
-    if (![self.onAppear hasExtension:innertubeCommandDescriptor])
-        return %orig;
-    YTICommand *innertubeCommand = [self.onAppear getExtension:innertubeCommandDescriptor];
-    GPBExtensionDescriptor *updateShareSheetCommandDescriptor = [%c(YTIUpdateShareSheetCommand) updateShareSheetCommand];
-    if(![innertubeCommand hasExtension:updateShareSheetCommandDescriptor])
-        return %orig;
-    YTIUpdateShareSheetCommand *updateShareSheetCommand = [innertubeCommand getExtension:updateShareSheetCommandDescriptor];
-    if (!updateShareSheetCommand.hasSerializedShareEntity)
-        return %orig;
-    if (!showNativeShareSheet(updateShareSheetCommand.serializedShareEntity))
-        return %orig;
-}
-%end
-
-//
 
 // iOS 16 uYou crash fix - @level3tjg: https://github.com/qnblackcat/uYouPlus/pull/224
 // %group iOS16
@@ -351,4 +191,7 @@ static void refreshUYouAppearance() {
 
     // Disable uYou's playback speed controls (prevent crash on video playback https://github.com/therealFoxster/uYouPlus/issues/2#issuecomment-1894912963)
     // [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"showPlaybackRate"];
+    
+    // Disable uYou's adblock
+    [[NSUserDefaults standardUserDefaults] setBool:NO forKey:@"removeYouTubeAds"];
 }


### PR DESCRIPTION
using uYouEnhanced's adblock does not seem to work. however using uYou's built in makes the main UI buggy and make elements vanish.

This branch allows you to use uYou adblock (which works! :D) as well as 'fixes' the missing UI elements (I also took the liberty of pointing the uYou download link to Miros repo which allows the installation of 3.0.4)

If you build this IPA ensure you install it over your existing uYouEnhanced installation as you will not be able to sign in or switch accounts due to the sign in 'spoof' being removed.

However this fixes the UI elements that are missing on the YT home page and a few other pages. This works well enough for me until a permanent solution is found